### PR TITLE
Added more user types and statuses to skip, more command oine options, pass API Key as a string argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ Super quick and dirty Python script to bulk invite ALL users in a slack team to 
 To use:
 * Install the [slacker](https://github.com/os/slacker) library via `pip`
 * [Get an API key](https://get.slack.help/hc/en-us/articles/215770388-Creating-and-regenerating-API-tokens)
-* Create a file in the same directory as `slack-bulkinviter.py` called `apikey.txt`, containing your API key
-* Execute the script, passing the name of the channel where all users will be invited, such as `./slack-bulkinviter.py mychannel`
+* Create a file in the same directory as `slack-bulkinviter.py` containing your API key and pass the filename to the argument `--apikey` or `-k`
+* Execute the script, passing the name of the channel where all users will be invited, such as `./slack-bulkinviter.py --channel mychannel`
 * Sit back and let it do its work

--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ Super quick and dirty Python script to bulk invite ALL users in a slack team to 
 To use:
 * Install the [slacker](https://github.com/os/slacker) library via `pip`
 * [Get an API key](https://get.slack.help/hc/en-us/articles/215770388-Creating-and-regenerating-API-tokens)
-* Create a file in the same directory as `slack-bulkinviter.py` containing your API key and pass the filename to the argument `--apikey` or `-k`
-* Execute the script, passing the name of the channel where all users will be invited, such as `./slack-bulkinviter.py --channel mychannel`
+* Optionally, if not using `--apikey`, create a file in the same directory as `slack-bulkinviter.py` containing your API key and pass the filename to the argument `--apikey` or `-k`
+* Execute the script, passing the name of the channel where all users will be invited, such as `./slack-bulkinviter.py --channel mychannel --apikey myapistring`
 * Sit back and let it do its work

--- a/slack-bulkinviter.py
+++ b/slack-bulkinviter.py
@@ -10,24 +10,31 @@ parser = argparse.ArgumentParser()
 parser.add_argument("-b", "--bots", action='store_true', help="Include bots in channel")
 parser.add_argument("-a", "--apps", action='store_true', help="Include apps in channel")
 parser.add_argument("-c", "--channel", required=True, metavar="<Channel Name>", help="Set channel name to add members")
-parser.add_argument("-k", "--apikey", required=True, metavar="<filename>", help="Path to API Key file")
+parser.add_argument("-k", "--apikey", metavar="'API Key Text String'", help="API Key string")
+parser.add_argument("-f", "--apifile", metavar="<filename>", help="Path to API Key file - only required is not using --apikey|-k")
 
 # read arguments from the command line
 args = parser.parse_args()
 
-# Load API key from apikey.txt
-try:
-    with open(args.apikey) as f:
-        api_key = f.read().strip()
-        assert api_key
-except IOError:
-    print("Cannot find API Key file {}, or other reading error".format(args.apikey))
-    sys.exit(1)
-except AssertionError:
-    print("Empty API key")
-    sys.exit(1)
+if args.apikey is None and args.apifile is None:
+    parser.error("You must pass an API Text String using --apikey or path to an APi Key File using --apifile")
+
+if args.apikey:
+    slack = Slacker(args.apikey)
 else:
-    slack = Slacker(api_key)
+    # Load API key from apikey.txt
+    try:
+        with open(args.apifile) as f:
+            api_key = f.read().strip()
+            assert api_key
+    except IOError:
+        print("Cannot find API Key file {}, or other reading error".format(args.apifile))
+        sys.exit(1)
+    except AssertionError:
+        print("Empty API key")
+        sys.exit(1)
+    else:
+        slack = Slacker(api_key)
 
 # Get channel id from name
 response = slack.channels.list()
@@ -41,7 +48,8 @@ channel_id = channels[0]['id']
 # Get users list
 response = slack.users.list()
 
-users = [(u['id'], u['name']) for u in response.body['members']]
+#users = [(u['id'], u['name']) for u in response.body['members']]
+users =[('U1T9U39PA', 'dkuei'), ('UAPLLKTA4', 'zendesk'), ('UARL5A8A1', 'bitbucket')]
 
 # Invite all users to slack channel
 for user_id, user_name in users:

--- a/slack-bulkinviter.py
+++ b/slack-bulkinviter.py
@@ -48,8 +48,7 @@ channel_id = channels[0]['id']
 # Get users list
 response = slack.users.list()
 
-#users = [(u['id'], u['name']) for u in response.body['members']]
-users =[('U1T9U39PA', 'dkuei'), ('UAPLLKTA4', 'zendesk'), ('UARL5A8A1', 'bitbucket')]
+users = [(u['id'], u['name']) for u in response.body['members']]
 
 # Invite all users to slack channel
 for user_id, user_name in users:

--- a/slack-bulkinviter.py
+++ b/slack-bulkinviter.py
@@ -46,7 +46,7 @@ for user_id, user_name in users:
         code = e.args[0]
         if code == "already_in_channel":
             print("{} is already in the channel".format(user_name))
-        elif code in ('cant_invite_self', 'cant_invite', 'user_is_ultra_restricted'):
+        elif code in ('cant_invite_self', 'cant_invite', 'user_is_ultra_restricted', 'ura_max_channels', 'cant_invite_app_user', 'is_bot', 'is_app_user'):
             print("Skipping user {} ('{}')".format(user_name, code))
         else:
             raise

--- a/slack-bulkinviter.py
+++ b/slack-bulkinviter.py
@@ -1,22 +1,27 @@
 #! /usr/bin/env python3
 import sys
+import argparse
 from slacker import Slacker, Error
 
-# Get channel name from command line
-try:
-    channel_name = sys.argv[1].strip('\'"')
-    assert channel_name
-except:
-    print("Please specify a channel name")
-    sys.exit(1)
+# Initiate the parser
+parser = argparse.ArgumentParser()
+
+# add long and short argument
+parser.add_argument("-b", "--bots", action='store_true', help="Include bots in channel")
+parser.add_argument("-a", "--apps", action='store_true', help="Include apps in channel")
+parser.add_argument("-c", "--channel", required=True, metavar="<Channel Name>", help="Set channel name to add members")
+parser.add_argument("-k", "--apikey", required=True, metavar="<filename>", help="Path to API Key file")
+
+# read arguments from the command line
+args = parser.parse_args()
 
 # Load API key from apikey.txt
 try:
-    with open('apikey.txt') as f:
+    with open(args.apikey) as f:
         api_key = f.read().strip()
         assert api_key
 except IOError:
-    print("Cannot find apikey.txt, or other reading error")
+    print("Cannot find API Key file {}, or other reading error".format(args.apikey))
     sys.exit(1)
 except AssertionError:
     print("Empty API key")
@@ -26,7 +31,7 @@ else:
 
 # Get channel id from name
 response = slack.channels.list()
-channels = [d for d in response.body['channels'] if d['name'] == channel_name]
+channels = [d for d in response.body['channels'] if d['name'] == args.channel]
 if not len(channels):
     print("Cannot find channel")
     sys.exit(1)
@@ -35,19 +40,24 @@ channel_id = channels[0]['id']
 
 # Get users list
 response = slack.users.list()
+
 users = [(u['id'], u['name']) for u in response.body['members']]
 
 # Invite all users to slack channel
 for user_id, user_name in users:
-    print("Inviting {} to {}".format(user_name, channel_name))
+    print("Inviting {} to {}".format(user_name, args.channel))
     try:
         slack.channels.invite(channel_id, user_id)
     except Error as e:
         code = e.args[0]
         if code == "already_in_channel":
             print("{} is already in the channel".format(user_name))
-        elif code in ('cant_invite_self', 'cant_invite', 'user_is_ultra_restricted', 'ura_max_channels', 'cant_invite_app_user', 'is_bot', 'is_app_user'):
+        elif code in ('cant_invite_self', 'cant_invite', 'user_is_ultra_restricted', 'ura_max_channels', 'cant_invite_app_user'):
             print("Skipping user {} ('{}')".format(user_name, code))
+        elif code in ('is_bot') and not args.bots:
+            print("Skipping bot user {} ('{}')".format(user_name, code))
+        elif code in ('is_app_user') and not args.apps:
+            print("Skipping app user {} ('{}')".format(user_name, code))
         else:
             raise
 

--- a/slack-bulkinviter.py
+++ b/slack-bulkinviter.py
@@ -1,12 +1,14 @@
 #! /usr/bin/env python3
 import sys
 import argparse
+import time
 from slacker import Slacker, Error
 
 # Initiate the parser
 parser = argparse.ArgumentParser()
 
 # add long and short argument
+parser.add_argument("-s", "--sleep", type=int, default=0, help="Seconds to sleep between API calls. DEfaults to 0.")
 parser.add_argument("-b", "--bots", action='store_true', help="Include bots in channel")
 parser.add_argument("-a", "--apps", action='store_true', help="Include apps in channel")
 parser.add_argument("-c", "--channel", required=True, metavar="<Channel Name>", help="Set channel name to add members")
@@ -67,4 +69,8 @@ for user_id, user_name in users:
             print("Skipping app user {} ('{}')".format(user_name, code))
         else:
             raise
+
+    if args.sleep:
+        print("Sleeping {} seconds".format(args.sleep))
+        time.sleep(args.sleep)
 


### PR DESCRIPTION
I was having problems with certain user statuses causing the script to fail, specifically `ura_max_channels` for users restricted to certain channels and `cant_invite_app_user`. I also did not want bots and apps added to the channel by default. I added command line options for the channel, apikey file, and whether or not to add bots and apps (default, False) to the channel.