### PR TITLE
Handle cant_invite_app_user error gracefully

### DIFF
--- a/slack-bulkinviter.py
+++ b/slack-bulkinviter.py
@@ -46,7 +46,7 @@ for user_id, user_name in users:
         code = e.args[0]
         if code == "already_in_channel":
             print("{} is already in the channel".format(user_name))
-        elif code in ('cant_invite_self', 'cant_invite', 'user_is_ultra_restricted'):
+        elif code in ('cant_invite_self', 'cant_invite', 'user_is_ultra_restricted', 'cant_invite_app_user'):
             print("Skipping user {} ('{}')".format(user_name, code))
         else:
             raise


### PR DESCRIPTION
Slack seems to have an extra error case that I believe should be handled gracefully.

This error was thrown when trying to invite a github app user.

```
Inviting github to channel
Traceback (most recent call last):
  File "./slack-bulkinviter.py", line 44, in <module>
    slack.channels.invite(channel_id, user_id)
  File "/usr/local/Cellar/python3/3.6.4/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/slacker/__init__.py", line 314, in invite
    data={'channel': channel, 'user': user})
  File "/usr/local/Cellar/python3/3.6.4/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/slacker/__init__.py", line 123, in post
    api, **kwargs
  File "/usr/local/Cellar/python3/3.6.4/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/slacker/__init__.py", line 99, in _request
    raise Error(response.error)
slacker.Error: cant_invite_app_user
```